### PR TITLE
fix(manifests): specify nginx image version to 1.25

### DIFF
--- a/nginx-rc.yml
+++ b/nginx-rc.yml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: nginx:1.25
         ports:
         - containerPort: 80

--- a/nginx-rs.yml
+++ b/nginx-rs.yml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: nginx:1.25
         ports:
         - containerPort: 80


### PR DESCRIPTION
## 변경 사항
- `nginx-rc.yml`: `nginx` → `nginx:1.25`
- `nginx-rs.yml`: `nginx` → `nginx:1.25`

## 관련 이슈
Closes #1

## 테스트
- [ ] 로컬 클러스터에서 적용 확인