### PR TITLE
feat(manifests): add mysql StatefulSet manifests

### DIFF
--- a/mysql-headless-svc.yml
+++ b/mysql-headless-svc.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+spec:
+  clusterIP: None
+  selector:
+    app: mysql
+  ports:
+  - port: 3306

--- a/mysql-statefulset.yml
+++ b/mysql-statefulset.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+spec:
+  serviceName: mysql-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: "password123"
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
## 변경 사항
- `mysql-headless-svc.yml` : MySQL용 Headless Service 추가
- `mysql-statefulset.yml` : MySQL StatefulSet (3 replicas) 추가

## 관련 이슈
Closes #17

## 테스트
- [ ] 로컬 클러스터에서 적용 확인