### PR TITLE
docs: remove scope from commit message convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ docs/3-update-readme
 ## 커밋 메시지 (Conventional Commits)
 
 ```
-<type>(<scope>): <subject>
+<type>: <subject>
 
 [body]
 
@@ -55,7 +55,7 @@ docs/3-update-readme
 
 **예시**
 ```
-feat(deployment): add nginx deployment manifest
+feat: add nginx deployment manifest
 
 Add rolling update strategy with maxSurge 1 and maxUnavailable 0
 to ensure zero-downtime deployments.


### PR DESCRIPTION
## 변경 사항
- 커밋 메시지 형식을 `<type>(<scope>): <subject>` → `<type>: <subject>`로 변경
- 예시 커밋 메시지도 동일하게 수정

## 관련 이슈
Closes #23

## 테스트
- [ ] 로컬 클러스터에서 적용 확인